### PR TITLE
Add threshold clamping to prevent loud sounds from compressing quiete…

### DIFF
--- a/src/main/java/org/wavelabs/soundscope/view/UIStyle.java
+++ b/src/main/java/org/wavelabs/soundscope/view/UIStyle.java
@@ -32,6 +32,7 @@ public class UIStyle {
         
         public static final Color WAVEFORM_STROKE = new Color(0, 100, 255);
         public static final Color WAVEFORM_PLAYED = Color.RED; // Red for played portion
+        public static final Color WAVEFORM_CLIPPED = new Color(255, 165, 0); // Orange for clipped/overload portions
         public static final Color WAVEFORM_BACKGROUND = Color.WHITE;
         public static final Color PLAYBACK_INDICATOR = Color.RED;
     }


### PR DESCRIPTION

- Use fixed normalization reference level (0.1) instead of scaling to max
- Clamp waveform display at 80% threshold - exceeded parts are not displayed
- Prevents loud sounds from compressing the display of quieter sounds
- Quieter sounds maintain consistent relative size regardless of loud peaks